### PR TITLE
rboot: Allow XTENSA_BINDIR to be set blank

### DIFF
--- a/rboot/Makefile
+++ b/rboot/Makefile
@@ -5,9 +5,9 @@
 
 ESPTOOL2 ?= D:/Projects/esp8266/esptool2/Release/esptool2.exe
 
-XTENSA_BINDIR ?= C:/xtensa-lx106-elf/bin
-CC := $(addprefix $(XTENSA_BINDIR)/,xtensa-lx106-elf-gcc)
-LD := $(addprefix $(XTENSA_BINDIR)/,xtensa-lx106-elf-gcc)
+XTENSA_BINDIR ?= C:/xtensa-lx106-elf/bin/
+CC := $(addprefix $(XTENSA_BINDIR),xtensa-lx106-elf-gcc)
+LD := $(addprefix $(XTENSA_BINDIR),xtensa-lx106-elf-gcc)
 
 CFLAGS    = -Os -O3 -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
 LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static


### PR DESCRIPTION
If toolchain binaries are on your PATH already, this allows you to pass
XTENSA_BINDIR= and have them automatically picked up.
